### PR TITLE
Fix config permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ USER root
 RUN apk --update add --no-cache logrotate && \
     rm -f /etc/logrotate.d/*
 ADD logrotate.conf /etc/logrotate.conf
+RUN chmod 0400 /etc/logrotate.conf
 
 CMD ["/usr/sbin/logrotate", "-v", "-f", "--state","/tmp/logrotate.status", "/etc/logrotate.conf"]


### PR DESCRIPTION
This PR will fix warning:
```
Potentially dangerous mode on /etc/logrotate.conf: 0664                                                                                                      
error: Ignoring /etc/logrotate.conf because it is writable by group or others.                                                                               
Reading state from file: /tmp/logrotate.status                                                                                                               
Allocating hash table for state file, size 64 entries
```